### PR TITLE
normalizes card layout

### DIFF
--- a/src/components/card/card.module.css
+++ b/src/components/card/card.module.css
@@ -1,11 +1,12 @@
 .cardBody {
     position: relative;
     display: flex;
-    justify-content: space-evenly;
+    justify-content: space-between;
     flex-direction: column;
     align-items:center;
     width: 180px;
     height: 290px;
+    padding: 5% 5% 5% 5%;
     background-color: rgba(255, 255, 255, 0.5);
     border: 1px solid white;
     border-radius: 2px;
@@ -13,21 +14,18 @@
     top: 0;
     left: 0;
     transition: transform 1s;
+    overflow: hidden;
 }
 .hoverEffect:hover {
     box-shadow: 0 0 3px 2px rgba(255, 255, 255, 0.6);
     cursor: pointer;
 }
 .disabled {
-    width: 180px;
-    height: 290px;
-    z-index: 9;
-    background-color: rgba(0, 0, 0, 0.5);
-    position: absolute;
+    filter: brightness(50%);
 }
 .imgContainerDiv {
-    width: 160px;
-    height: 160px;
+    width: 100%;
+    height: 60%;
     background-color: rgba(0, 0, 0, 0.6);
     border-top-left-radius: 100%266%;
     border-top-right-radius: 100%266%; 
@@ -35,9 +33,9 @@
     border-bottom-right-radius: 100%266%;
 }
 .img {
-    width: 160px;
-    height: 160px;
-    object-fit: fill;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
     background-color: rgba(0, 0, 0, 0.6);
     border-top-left-radius: 100%266%;
     border-top-right-radius: 100%266%; 
@@ -45,26 +43,30 @@
     border-bottom-right-radius: 100%266%;
 }
 .titleSpan {
-    height: 42px;
+    height: 12%;
     display: flex;
     justify-content: center;
     align-items: center;
+    line-height: 1em;
 }
 .textSpan {
-    height: 60px;
-    display: flex;
+    height: 15%;
+    overflow-y: scroll;
     justify-content: center;
+    align-items: center;
     font-size: 14px;
 }
+.cardFooter {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
 .cardCost {
-    position: absolute;
-    right: 158px;
-    top: 260px;
+    line-height: 1em;
 }
 .cardIcon {
-    position: absolute;
-    left: 153px;
-    top: 260px;
 }
 .defense {
     background-color: rgba(51, 51, 51, 0.8);

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -27,21 +27,22 @@ const Card = ({ card, stats, turn, cardNum, active }: Props) => {
     const img = cardTypeIcons[card.type]
     const isActive = active === cardNum
     const disabled = (!isActive && active) || card.cost > stats[resMap[card.type]]
+    const cardBack = (turn === 2 && !isActive)
 
     return (
         <>
-            <div id={`card-${cardNum}`} className={`${styles[`${card.type}`]} ${styles.cardBody} ${(!disabled && !isActive && turn !== 2) && styles.hoverEffect}`}>
-                {(turn === 2 && !isActive) && <div className='card-back'></div>}
-                <div hidden={!disabled || isActive} className={styles.disabled}></div>
-                <span className={styles.titleSpan}>{card.name}</span>
-                <div className={styles.imgContainerDiv}>
-                    <img className={styles.img} src={imageFilename(card.name)} />
-                </div>
-                <span className={styles.textSpan}>{card.description}</span>
-                <span className={styles.cardCost}>{card.cost}</span>
-                <div className={styles.cardIcon}>
-                    <Image width={20} height={20} alt={`${card.type} icon`} src={img} />
-                </div>
+            <div id={`card-${cardNum}`} className={`${styles[`${card.type}`]} ${styles.cardBody} ${disabled && turn === 1 && !isActive && styles.disabled} ${(!disabled && !isActive && turn !== 2) && styles.hoverEffect} ${cardBack && 'card-back'}`}>
+                {!cardBack && <>
+                    <span className={styles.titleSpan}>{card.name}</span>
+                    <div className={styles.imgContainerDiv}>
+                        <img className={styles.img} src={imageFilename(card.name)} />
+                    </div>
+                    <span className={styles.textSpan}>{card.description}</span>
+                    <div className={styles.cardFooter}>
+                        <span className={styles.cardCost}>{card.cost}</span>
+                        <Image width={20} height={20} alt={`${card.type} icon`} src={img} />
+                    </div>
+                </>}
             </div>
         </>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -30,14 +30,8 @@ a {
   position: relative;
 }
 .card-back {
-  position: absolute;
-  width: 180px;
-  height: 290px;
-  border: 1px solid white;
-  border-radius: 2px;
   overflow: hidden;
   background: center no-repeat url('../public/images/card-back.jpg');
-  z-index: 10;
 }
 @media (prefers-color-scheme: dark) {
   html {


### PR DESCRIPTION
This changeset removes some unnecessary utility divs and absolute positionings.
1. The "inactive" low opacity div has been removed. Its responsibility has been placed upon the parent card layout div.
2. The card back div has been removed. Its responsibility has been placed upon the parent card layout div (to apply the background picture) and a conditional card contents rendering fragment within div.
3. The absolute positioning of the card footer elements has been replaced. This will allow for dynamic card sizes in the future.